### PR TITLE
Add comma before env in template

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -17,7 +17,7 @@ module.exports = {
   // The Application ID of the Discord bot
 	applicationId: '',
   // This is where the path to command files are, .ts files are supported!
-  commandsPath: './commands'
+  commandsPath: './commands',
   // You can use different environments with --env (-e)
   env: {
 		development: {


### PR DESCRIPTION
After the `commandsPath` export in the template config file there was no comma before the `env` export and would lead to a `✖ Unexpected identifier` error. This adds the needed comma and fixes this error.

Current version:
![image](https://user-images.githubusercontent.com/56032728/146852199-571a72cc-fc1b-4852-b840-f06b0cd484e0.png)

Changed version:
![image](https://user-images.githubusercontent.com/56032728/146852266-2f55a752-5921-45f8-b8d1-11b5adda97dd.png)
